### PR TITLE
Тренировка ResNet18

### DIFF
--- a/models/resnet18/resnet18.yaml
+++ b/models/resnet18/resnet18.yaml
@@ -1,0 +1,32 @@
+model:
+  _target_: unsupervised_pretraining.model.resnet18.ResNet18
+
+  pretrained: False
+  num_classes: 10  # количество классов в датасете STL10
+  learning_rate: 3e-4  # шаг обучения классификатора
+
+augmentations:
+  train_transforms:
+    normalize:
+      _target_: albumentations.augmentations.transforms.Normalize
+      _convert_: all
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    resize:
+      _target_: albumentations.augmentations.geometric.resize.Resize
+      height: 224
+      width: 224
+    to_tensor:
+      _target_: albumentations.pytorch.transforms.ToTensorV2
+  test_transforms:
+    normalize:
+      _target_: albumentations.augmentations.transforms.Normalize
+      _convert_: all
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+    resize:
+      _target_: albumentations.augmentations.geometric.resize.Resize
+      height: 224
+      width: 224
+    to_tensor:
+      _target_: albumentations.pytorch.transforms.ToTensorV2


### PR DESCRIPTION
Имплементировал тренировку ResNet18 с нуля.
Запустить можно стандартным способом, указав конфиг модели (./models/resnet18/resnet18.yaml).